### PR TITLE
ST-55 Firstname and lastname MaxLength error message added

### DIFF
--- a/src/app/core/rest/services/notification.service.ts
+++ b/src/app/core/rest/services/notification.service.ts
@@ -27,7 +27,7 @@ export class NotificationService {
     });
   }
 
-  showErrorNotification (component: string, resultKeys: string[]) {
+  showErrorNotification (component: string, resultKeys: string[]): void {
     const notificationTitle = this.translate.instant(`${component}.errorNotificationTitle`);
     let notificationMessage = '';
     for(const key of resultKeys) {

--- a/src/app/modules/user/new-user/new-user.component.ts
+++ b/src/app/modules/user/new-user/new-user.component.ts
@@ -56,12 +56,20 @@ export class NewUserComponent implements OnInit {
     {
       key: 'minlength',
       customKey: 'firstName-min-length'
+    },
+    {
+      key: 'maxlength',
+      customKey: 'firstName-max-length'
     }
   ];
   customLastNameErrorMsgs = [
     {
       key: 'minlength',
       customKey: 'lastName-min-length'
+    },
+    {
+      key: 'maxlength',
+      customKey: 'lastName-max-length'
     }
   ];
   customConfirmEmailErrorMsgs = [

--- a/src/app/modules/user/user-settings/user-settings.component.ts
+++ b/src/app/modules/user/user-settings/user-settings.component.ts
@@ -206,7 +206,7 @@ export class UserSettingsComponent implements OnInit {
       ...this.userSettingsForm.value,
       email: email === '' ? null : email,
       confirmEmail: confirmEmail === '' ? null : confirmEmail
-    }
+    };
 
     this.userService.updateUser(this.currentUser.id, data)
       .pipe(

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -76,7 +76,9 @@
     "password-max-length": "La contraseña debe contener como máximo 20 caracteres.",
     "password-not-match": "Las contraseñas deben coincidir",
     "firstName-min-length": "El nombre debe contener 2 caracteres o más.",
+    "firstName-max-length": "El nombre puede contener un máximo de 60 caracteres.",
     "lastName-min-length": "El apellido debe contener 2 caracteres o más.",
+    "lastName-max-length": "El apellido puede contener un máximo de 60 caracteres.",
     "email": "Ingrese un email valido.",
     "email-not-match": "El email debe coincidir."
   },


### PR DESCRIPTION
This PR fixes the following [ticket](https://stocktracker.atlassian.net/browse/ST-55)

[CHANGES]
Now when entering more than 50 chars in firstname and lastname fields, a message saying that the field can contain up to 50 chars will appear.