### PR TITLE
ST-54 added error message when leaving a required field empty

### DIFF
--- a/src/app/modules/user/new-user/new-user.component.html
+++ b/src/app/modules/user/new-user/new-user.component.html
@@ -135,7 +135,6 @@
             <button 
               stPrimaryBtn
               (click)="onSubmit()"
-              [disabled]='registerForm.invalid'
               style="margin-right: 15px;"
             >
               {{ 'NewUserComponent.submit' | translate }}


### PR DESCRIPTION
This PR fixes the following [ticket](https://stocktracker.atlassian.net/browse/ST-54)

[CHANGES]
Removed disabled property from submit button and added an error message when a required field is leaving empty when submitting the form.