### PR TITLE
ST-76 added validations to firstname and lastname fields

### DIFF
--- a/src/app/modules/user/new-user/new-user.component.ts
+++ b/src/app/modules/user/new-user/new-user.component.ts
@@ -60,6 +60,10 @@ export class NewUserComponent implements OnInit {
     {
       key: 'maxlength',
       customKey: 'firstName-max-length'
+    },
+    {
+      key: 'space-at-beginning',
+      customKey: 'firstName-space-at-beginning'
     }
   ];
   customLastNameErrorMsgs = [
@@ -70,6 +74,10 @@ export class NewUserComponent implements OnInit {
     {
       key: 'maxlength',
       customKey: 'lastName-max-length'
+    },
+    {
+      key: 'space-at-beginning',
+      customKey: 'lastName-space-at-beginning'
     }
   ];
   customConfirmEmailErrorMsgs = [
@@ -213,6 +221,30 @@ export class NewUserComponent implements OnInit {
         next: noop,
         error: err => console.log(err)
       });
+
+      this.registerForm.get('firstName')?.valueChanges
+        .pipe(
+          tap((value: string) => {
+            if (value[0] === ' ') this.registerForm.get('firstName')?.setErrors({'firstName-space-at-beginning': true});
+            if (value.trimEnd().length < 2) this.registerForm.get('firstName')?.setErrors({'firstName-min-length': true});
+          })
+        )
+        .subscribe({
+          next: noop,
+          error: err => console.log(err)
+        });
+      
+      this.registerForm.get('lastName')?.valueChanges
+        .pipe(
+          tap((value: string) => {
+            if (value[0] === ' ') this.registerForm.get('lastName')?.setErrors({'lastName-space-at-beginning': true});
+            if (value.trimEnd().length < 2) this.registerForm.get('lastName')?.setErrors({'lastName-min-length': true});
+          })
+        )
+        .subscribe({
+          next: noop,
+          error: err => console.log(err)
+        });
   }
 
   ngOnInit (): void {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -73,6 +73,8 @@
     "firstName-max-length": "El nombre puede contener un máximo de 60 caracteres.",
     "lastName-min-length": "El apellido debe contener 2 caracteres o más.",
     "lastName-max-length": "El apellido puede contener un máximo de 60 caracteres.",
+    "firstName-space-at-beginning": "El nombre no puede iniciar con un espacio.",
+    "lastName-space-at-beginning": "El apellido no puede iniciar con un espacio.",
     "email": "Ingrese un email valido.",
     "email-not-match": "El email debe coincidir.",
     "description-max-length": "La descripción del nivel puede contener un máximo de 200 caracteres.",


### PR DESCRIPTION
This PR fixes the following [ticket](https://stocktracker.atlassian.net/browse/ST-76)

[CHANGES]
Added a validation that checks if firstname and lastname inputs begin with a whitespace and if their length is less than 2 after removing any trailing whitespace.